### PR TITLE
ci: add NuxtHub deployment workflow and Dependabot setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/nuxthub.yml
+++ b/.github/workflows/nuxthub.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build application
         run: pnpm build
+        env:
+          NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
 
       - name: Deploy to NuxtHub
         uses: nuxt-hub/action@v1

--- a/.github/workflows/nuxthub.yml
+++ b/.github/workflows/nuxthub.yml
@@ -1,0 +1,40 @@
+name: Deploy to NuxtHub
+on: push
+
+jobs:
+  deploy:
+    name: "Deploy to NuxtHub"
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Ensure NuxtHub module is installed
+        run: pnpx nuxthub@latest ensure
+
+      - name: Build application
+        run: pnpm build
+
+      - name: Deploy to NuxtHub
+        uses: nuxt-hub/action@v1
+        id: deploy
+        with:
+          project-key: git-replay-2reb


### PR DESCRIPTION
This PR introduces CI/CD and automated dependency management for `GitReplay`:

* 🚀 **NuxtHub CI workflow** (`.github/workflows/nuxthub.yml`)

  * Automatically deploys to NuxtHub on every push
  * Differentiates between `preview` and `production` environments
  * Uses `pnpm`, Node.js v22, and installs the NuxtHub module
  * Supports `@nuxt/ui-pro` license injection via GitHub secrets

* 📦 **Dependabot config** (`.github/dependabot.yml`)

  * Enables weekly updates for `npm` ecosystem (via `pnpm`)
  * Keeps dependencies fresh and secure

This sets up the foundation for continuous deployment and security hygiene.
