### PR TITLE
fix(auth): configure IP address headers for GitHub auth

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -17,5 +17,10 @@ export function auth() {
         clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
       },
     },
+    advanced: {
+      ipAddress: {
+        ipAddressHeaders: ['cf-connecting-ip', 'x-forwarded-for'],
+      },
+    },
   })
 }


### PR DESCRIPTION
Adds support for IP extraction from reverse proxy headers to ensure accurate IP detection during authentication flows.

* Configures `advanced.ipAddress` with `cf-connecting-ip` and `x-forwarded-for`
* Supports deployments behind Cloudflare or other reverse proxies

No breaking changes. Improves security and audit trail accuracy for authenticated sessions.
